### PR TITLE
14 focustimer pop up sending requests

### DIFF
--- a/common/api/api.ts
+++ b/common/api/api.ts
@@ -208,10 +208,10 @@ export function useUpdateUserStatus() {
   const mutation = useMutation({
     mutationFn: async (status: UserStatus) => {
       const response = await authFetch(
-        `${import.meta.env.WXT_API_BASE_URI}/user`,
+        `${import.meta.env.WXT_API_BASE_URI}/user/status`,
         {
           method: "PUT",
-          body: JSON.stringify({ status }),
+          body: JSON.stringify({ user_status: status }),
         }
       );
       if (!response.ok) {
@@ -226,13 +226,12 @@ export function useUpdateUserStatus() {
 }
 
 export function useAddFocusSession() {
-  // const client = useQueryClient();
-  // const authFetch = useAuthFetch();
+  const client = useQueryClient();
+  const authFetch = useAuthFetch();
 
   const mutation = useMutation({
     mutationFn: async ( data: FocusSessionModel ) => {
-      // const response = await authFetch(
-      const response = await fetch(
+      const response = await authFetch(
         `${import.meta.env.WXT_API_BASE_URI}/focustimer`,
         {
           method: "POST",
@@ -249,7 +248,7 @@ export function useAddFocusSession() {
       return responseData;
     },
     onSuccess: () => {
-      // client.invalidateQueries({ queryKey: ["focustimer"] });
+      client.invalidateQueries({ queryKey: ["focustimer"] });
     },
   });
   return mutation;

--- a/common/api/api.ts
+++ b/common/api/api.ts
@@ -5,7 +5,7 @@ import {
   getBlocklistFromLocalStorage,
   setBlocklistToLocalStorage,
 } from "../core/blocklist";
-import { setJWTToLocalStorage } from "../core/user";
+import { setJWTToLocalStorage, getJWTFromLocalStorage } from "../core/user";
 
 export const BlockListType = {
   Work: 0,
@@ -307,4 +307,60 @@ export function useDeleteFocusSession() {
     },
   });
   return mutation;
+}
+
+export function updateFocusSession(sessionId: string, data: any): Promise<any> {
+  return getJWTFromLocalStorage().then((user) => {
+    if (!user?.jwt) {
+      return Promise.reject(new Error("No JWT token found"));
+    }
+
+    return fetch(`${import.meta.env.WXT_API_BASE_URI}/focustimer/${sessionId}`, {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Auth-Token": user.jwt,
+      },
+      body: JSON.stringify(data),
+    })
+      .then(async (response) => {
+        if (!response.ok) {
+          const errorData = await response.json();
+          throw new Error(errorData.message || "Failed to update session");
+        }
+        return response.json();
+      })
+      .catch((error) => {
+        console.error("Error updating focus session:", error);
+        throw error;
+      });
+  });
+}
+
+export function updateUserStatus(data: any): Promise<any> {
+  return getJWTFromLocalStorage().then((user) => {
+    if (!user?.jwt) {
+      return Promise.reject(new Error("No JWT token found"));
+    }
+
+    return fetch(`${import.meta.env.WXT_API_BASE_URI}/user/status`, {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Auth-Token": user.jwt,
+      },
+      body: JSON.stringify(data),
+    })
+      .then(async (response) => {
+        if (!response.ok) {
+          const errorData = await response.json();
+          throw new Error(errorData.message || "Failed to update user status");
+        }
+        return response.json();
+      })
+      .catch((error) => {
+        console.error("Error updating user status:", error);
+        throw error;
+      });
+  });
 }

--- a/entrypoints/background/focusTimerBackground.ts
+++ b/entrypoints/background/focusTimerBackground.ts
@@ -5,6 +5,7 @@ let breakLength = 10;
 let focusType = "Choose a focus type";
 let remainingFocusTime = 30 * 60;
 let remainingBreakTime = 10 * 60;
+let sessionId = "";
 const ports: chrome.runtime.Port[] = [];
 
 interface Message {
@@ -15,6 +16,7 @@ interface Message {
   focusType?: string;
   remainingFocusTime?: number;
   remainingBreakTime?: number;
+  sessionId?: string;
 }
 
 export function timerListener(port: chrome.runtime.Port) {
@@ -68,6 +70,7 @@ function startFocusSession(message: Message) {
   focusType = message.focusType ?? "Choose a focus type";
   remainingFocusTime = focusLength * 60;
   remainingBreakTime = breakLength * 60;
+  sessionId = message.sessionId ?? "";
   startTimer();
   broadcastMessage(getCurrentState());
   console.log("StartFocusSession", message);
@@ -127,6 +130,7 @@ function resetState() {
   focusType = "Choose a focus type";
   remainingFocusTime = 30 * 60;
   remainingBreakTime = 10 * 60;
+  sessionId = "";
 }
 
 function broadcastMessage(message: Message) {
@@ -148,5 +152,6 @@ function getCurrentState(): Message {
     focusType,
     remainingFocusTime,
     remainingBreakTime,
+    sessionId,
   };
 }

--- a/entrypoints/popup/routes/focusTimer/FocusTimer.tsx
+++ b/entrypoints/popup/routes/focusTimer/FocusTimer.tsx
@@ -142,8 +142,8 @@ const FocusTimer = () => {
         duration: focusLength,
         break_duration: breakLength,
         session_type: FocusSessionType[focusType as keyof typeof FocusSessionType],
-        remaining_focus_time: remainingFocusTime,
-        remaining_break_time: remainingBreakTime,
+        remaining_focus_time: focusLength * 60,
+        remaining_break_time: breakLength * 60,
       };
       addMutation.mutate( request,
         {
@@ -230,7 +230,7 @@ const FocusTimer = () => {
     );
   };
 
-  const completeSession = () => { 
+  const completeSession = () => {
     const request = {
       session_status: FocusSessionStatus.Completed,
       remaining_focus_time: remainingFocusTime,
@@ -363,7 +363,7 @@ const FocusTimer = () => {
           <p>Time left for this focus session:</p>
           <CountdownTimer
             seconds={Math.floor(remainingFocusTime)}
-            onComplete={completeSession}
+            onComplete={idleState}
           />
           <div className="button-container">
             <Button
@@ -386,7 +386,7 @@ const FocusTimer = () => {
           <p>Time left for this break session:</p>
           <CountdownTimer
             seconds={Math.floor(remainingBreakTime)}
-            onComplete={endBreak}
+            onComplete={backToFocusState}
           />
           <div className="button-container">
             <Button className="button1" onClick={endBreak}>

--- a/entrypoints/popup/routes/focusTimer/FocusTimer.tsx
+++ b/entrypoints/popup/routes/focusTimer/FocusTimer.tsx
@@ -30,8 +30,8 @@ const FocusTimer = () => {
   const [sessionId, setSessionId] = useState<string>("");
 
   const addMutation = useAddFocusSession();
-  // const updateMutation = useUpdateFocusSession();
-  // const updateStatusMutation = useUpdateUserStatus();
+  const updateMutation = useUpdateFocusSession();
+  const updateStatusMutation = useUpdateUserStatus();
 
   useEffect(() => {
     // Connect to the background script
@@ -48,6 +48,7 @@ const FocusTimer = () => {
         setFocusType(message.focusType);
         setRemainingFocusTime(message.remainingFocusTime);
         setRemainingBreakTime(message.remainingBreakTime);
+        setSessionId(message.sessionId);
       } else if (message.type === "TIMER_UPDATE") {
         setRemainingFocusTime(message.remainingFocusTime);
         setRemainingBreakTime(message.remainingBreakTime);
@@ -122,15 +123,6 @@ const FocusTimer = () => {
   const startFocus = () => {
     setStartClicked(true);
     if (focusLength > 0 && focusType != "Choose a focus type") {
-      // TODO: check for overlap sessions
-      startFocusState();
-      port?.postMessage({
-        type: "START_FOCUS",
-        focusLength,
-        breakLength,
-        focusType,
-      });
-      // TODO: add request to create focus session and update user status
       const now = new Date();
       const formattedDate = now.toLocaleDateString("en-US", {
         month: "2-digit",
@@ -161,92 +153,109 @@ const FocusTimer = () => {
           onSuccess(data) {
             console.log(data);
             setSessionId(data.id);
+
+            startFocusState();
+            port?.postMessage({
+              type: "START_FOCUS",
+              focusLength,
+              breakLength,
+              focusType,
+              sessionId: data.id,
+            });
           }
         }
       );
-      // updateStatusMutation.mutate(
-      //   UserStatus[focusType as keyof typeof UserStatus],
-      //   {
-      //     onError(err) {
-      //       console.error(err);
-      //     },
-      //   }
-      // );
+      updateStatusMutation.mutate(
+        UserStatus[focusType as keyof typeof UserStatus],
+        {
+          onError(err) {
+            console.error(err);
+          },
+        }
+      );
       
       setStartClicked(false);
     }
   };
 
   const startBreak = () => {
-    restState();
-    port?.postMessage({ type: "START_BREAK" });
-    // TODO: add request to update focus session and user status
-    // const request = {
-    //   session_status: FocusSessionStatus.Paused,
-    //   remaining_focus_time: remainingFocusTime,
-    //   remaining_break_time: remainingBreakTime,
-    // };
-    // updateMutation.mutate({ sessionId, data: request }, {
-    //   onError(err) {
-    //     console.error(err);
-    //   },
-    // });
-    // updateStatusMutation.mutate(
-    //   UserStatus.Idle,
-    //   {
-    //     onError(err) {
-    //       console.error(err);
-    //     },
-    //   }
-    // );
+    const request = {
+      session_status: FocusSessionStatus.Paused,
+      remaining_focus_time: remainingFocusTime,
+      remaining_break_time: remainingBreakTime,
+    };
+    updateMutation.mutate({ sessionId, data: request }, {
+      onError(err) {
+        console.error(err);
+      },
+      onSuccess(data) {
+        console.log(data);
+        restState();
+        port?.postMessage({ type: "START_BREAK" });
+      }
+    });
+    updateStatusMutation.mutate(
+      UserStatus.Idle,
+      {
+        onError(err) {
+          console.error(err);
+        },
+      }
+    );
   };
 
   const endBreak = () => {
-    backToFocusState();
-    port?.postMessage({ type: "END_BREAK" });
-    // TODO: add request to update focus session and user status
-    // const request = {
-    //   session_status: FocusSessionStatus.Ongoing,
-    //   remaining_focus_time: remainingFocusTime,
-    //   remaining_break_time: remainingBreakTime,
-    // };
-    // updateMutation.mutate({ sessionId, data: request }, {
-    //   onError(err) {
-    //     console.error(err);
-    //   },
-    // });
-    // updateStatusMutation.mutate(
-    //   UserStatus[focusType as keyof typeof UserStatus],
-    //   {
-    //     onError(err) {
-    //       console.error(err);
-    //     },
-    //   }
-    // );
+    const request = {
+      session_status: FocusSessionStatus.Ongoing,
+      remaining_focus_time: remainingFocusTime,
+      remaining_break_time: remainingBreakTime,
+    };
+    updateMutation.mutate({ sessionId, data: request }, {
+      onError(err) {
+        console.error(err);
+      },
+      onSuccess(data) {
+        console.log(data);
+        backToFocusState();
+        port?.postMessage({ type: "END_BREAK" });
+      }
+    });
+    updateStatusMutation.mutate(
+      UserStatus[focusType as keyof typeof UserStatus],
+      {
+        onError(err) {
+          console.error(err);
+        },
+      }
+    );
   };
 
-  const completeSession = () => {
-    idleState();
-    port?.postMessage({ type: "STOP_SESSION" });
-    // TODO: add request to update focus session and user status
-    // const request = {
-    //   session_status: FocusSessionStatus.Completed,
-    //   remaining_focus_time: remainingFocusTime,
-    //   remaining_break_time: remainingBreakTime,
-    // };
-    // updateMutation.mutate({ sessionId, data: request }, {
-    //   onError(err) {
-    //     console.error(err);
-    //   },
-    // });
-    // updateStatusMutation.mutate(
-    //   UserStatus.Idle,
-    //   {
-    //     onError(err) {
-    //       console.error(err);
-    //     },
-    //   }
-    // );
+  const completeSession = () => { 
+    const request = {
+      session_status: FocusSessionStatus.Completed,
+      remaining_focus_time: remainingFocusTime,
+      remaining_break_time: remainingBreakTime,
+    };
+    updateMutation.mutate({ sessionId, data: request }, {
+      onError(err) {
+        console.error(err);
+      },
+      onSuccess(data) {
+        console.log(data);
+        idleState();
+        port?.postMessage({ type: "STOP_SESSION" });
+      }
+    });
+    if (currentState !== "rest") {
+      updateStatusMutation.mutate(
+        UserStatus.Idle,
+        {
+          onError(err) {
+            console.error(err);
+          },
+        }
+      );
+    }
   };
 
   return (

--- a/entrypoints/popup/routes/focusTimer/FocusTimer.tsx
+++ b/entrypoints/popup/routes/focusTimer/FocusTimer.tsx
@@ -1,3 +1,4 @@
+import { FocusSessionType, FocusSessionStatus, UserStatus, useAddFocusSession, useUpdateFocusSession, useUpdateUserStatus } from "@/common/api/api";
 import { useState, useEffect } from "react";
 import { browser } from "wxt/browser";
 import {
@@ -26,6 +27,11 @@ const FocusTimer = () => {
   );
   const [startClicked, setStartClicked] = useState<boolean>(false);
   const [port, setPort] = useState<chrome.runtime.Port | null>(null);
+  const [sessionId, setSessionId] = useState<string>("");
+
+  const addMutation = useAddFocusSession();
+  // const updateMutation = useUpdateFocusSession();
+  // const updateStatusMutation = useUpdateUserStatus();
 
   useEffect(() => {
     // Connect to the background script
@@ -125,6 +131,48 @@ const FocusTimer = () => {
         focusType,
       });
       // TODO: add request to create focus session and update user status
+      const now = new Date();
+      const formattedDate = now.toLocaleDateString("en-US", {
+        month: "2-digit",
+        day: "2-digit",
+        year: "numeric",
+      });
+      const formattedTime = now.toLocaleTimeString("en-US", {
+        hour: "2-digit",
+        minute: "2-digit",
+        second: "2-digit",
+        hour12: false,
+      });
+      const request = {
+        session_status: FocusSessionStatus.Ongoing,
+        start_date: formattedDate,
+        start_time: formattedTime,
+        duration: focusLength,
+        break_duration: breakLength,
+        session_type: FocusSessionType[focusType as keyof typeof FocusSessionType],
+        remaining_focus_time: remainingFocusTime,
+        remaining_break_time: remainingBreakTime,
+      };
+      addMutation.mutate( request,
+        {
+          onError(err) {
+            console.error(err);
+          },
+          onSuccess(data) {
+            console.log(data);
+            setSessionId(data.id);
+          }
+        }
+      );
+      // updateStatusMutation.mutate(
+      //   UserStatus[focusType as keyof typeof UserStatus],
+      //   {
+      //     onError(err) {
+      //       console.error(err);
+      //     },
+      //   }
+      // );
+      
       setStartClicked(false);
     }
   };
@@ -133,18 +181,72 @@ const FocusTimer = () => {
     restState();
     port?.postMessage({ type: "START_BREAK" });
     // TODO: add request to update focus session and user status
+    // const request = {
+    //   session_status: FocusSessionStatus.Paused,
+    //   remaining_focus_time: remainingFocusTime,
+    //   remaining_break_time: remainingBreakTime,
+    // };
+    // updateMutation.mutate({ sessionId, data: request }, {
+    //   onError(err) {
+    //     console.error(err);
+    //   },
+    // });
+    // updateStatusMutation.mutate(
+    //   UserStatus.Idle,
+    //   {
+    //     onError(err) {
+    //       console.error(err);
+    //     },
+    //   }
+    // );
   };
 
   const endBreak = () => {
     backToFocusState();
     port?.postMessage({ type: "END_BREAK" });
     // TODO: add request to update focus session and user status
+    // const request = {
+    //   session_status: FocusSessionStatus.Ongoing,
+    //   remaining_focus_time: remainingFocusTime,
+    //   remaining_break_time: remainingBreakTime,
+    // };
+    // updateMutation.mutate({ sessionId, data: request }, {
+    //   onError(err) {
+    //     console.error(err);
+    //   },
+    // });
+    // updateStatusMutation.mutate(
+    //   UserStatus[focusType as keyof typeof UserStatus],
+    //   {
+    //     onError(err) {
+    //       console.error(err);
+    //     },
+    //   }
+    // );
   };
 
   const completeSession = () => {
     idleState();
     port?.postMessage({ type: "STOP_SESSION" });
     // TODO: add request to update focus session and user status
+    // const request = {
+    //   session_status: FocusSessionStatus.Completed,
+    //   remaining_focus_time: remainingFocusTime,
+    //   remaining_break_time: remainingBreakTime,
+    // };
+    // updateMutation.mutate({ sessionId, data: request }, {
+    //   onError(err) {
+    //     console.error(err);
+    //   },
+    // });
+    // updateStatusMutation.mutate(
+    //   UserStatus.Idle,
+    //   {
+    //     onError(err) {
+    //       console.error(err);
+    //     },
+    //   }
+    // );
   };
 
   return (


### PR DESCRIPTION
## Summary

This PR implements communication between the front-end and back-end. Specifically, the following actions now trigger updates to both the `focus_timer` and `user`:
- `Start Focus Session` button clicked
- `Start Break` button clicked
- `Back to Focus Session` button clicked
- `End Current Session` button clicked
- Focus Session Time up
- Break Session Time up

## Tests
