### PR TITLE
state preserve

### DIFF
--- a/common/api/api.ts
+++ b/common/api/api.ts
@@ -560,3 +560,30 @@ export function useGetNextFocusSession() {
   return query;
 }
 
+export function getCurrFocusSession(): Promise<any> {
+  return getJWTFromLocalStorage().then((user) => {
+    if (!user?.jwt) {
+      return Promise.reject(new Error("No JWT token found"));
+    }
+
+    return fetch(`${import.meta.env.WXT_API_BASE_URI}/focustimer?session_status=${FocusSessionStatus.Ongoing},${FocusSessionStatus.Paused}`, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Auth-Token": user.jwt,
+      }
+    })
+      .then(async (response) => {
+        if (!response.ok) {
+          const errorData = await response.json();
+          throw new Error(errorData.message || "Failed to fetch focus session");
+        }
+        return response.json() as Promise<GetNextFocusSessionResponse>;;
+      })
+      .catch((error) => {
+        console.error("Error fetching current focus session:", error);
+        throw error;
+      });
+  });
+}
+

--- a/entrypoints/popup/routes/focusTimer/FocusTimer.tsx
+++ b/entrypoints/popup/routes/focusTimer/FocusTimer.tsx
@@ -17,7 +17,7 @@ import {
 import { Button } from "@/common/components/ui/button";
 import CountdownTimer from "./CountdownTimer";
 
-const SETTINGS_URL = browser.runtime.getURL("/dashboard.html#/");
+const SETTINGS_URL = browser.runtime.getURL("/dashboard.html#/Focustimer");
 
 const FocusTimer = () => {
   const [currentState, setCurrentState] = useState<"idle" | "focus" | "rest">(


### PR DESCRIPTION
## Summary
- Background updates remaining time to the backend every second
- During front-end restart: background fetch the ongoing/paused sessions and determine if session still alive (e.g. focus/break timer has not counted down to 0). If so, start the timer.

## Tests
